### PR TITLE
Optimize search/replace by using a precomputed lookuptable

### DIFF
--- a/diacriticless.js
+++ b/diacriticless.js
@@ -79,37 +79,36 @@ var diacritics =
 		'z' : ['z','ź','ż','ž','ƶ','ȥ','ɀ','ʐ','ʑ','ᙆ','ᙇ','ᶻ','ᶼ','ᶽ','ẑ','ẓ','ẕ','ⱬ','ｚ'],
 		'Z' : ['Z','Ź','Ż','Ž','Ƶ','Ȥ','ᴢ','ᵶ','Ẑ','Ẓ','Ẕ','Ⱬ','Ｚ']
 	};
+// Precompiled Object with { key = Diacritic, value = real-Character }
+var compiledDiactitics = {};
+
+// Precompile the Object, iterate the diacritics-Object
+for (var key in diacritics) {
+  ok = diacritics[key];
+
+  for (var rval in ok) {
+    var val = ok[rval];
+
+    // Do not replace the char with itself
+    if (val !== key) {
+      compiledDiactitics[val] = key;
+    }
+  }
+}
 
 /*
  * Main function of the module which removes all diacritics from the received text
  */
 module.exports = function (text) {
-    var result = [];
+  var result = "";
 
-	// iterate over all the characters of the received text
-    for(var i=0; i<text.length; i++) {
-        var searchChar = text.charAt(i);
-        var foundChar = false;
+  // iterate over all the characters of the received text
+  for (var i = 0; i < text.length; i++) {
+    var searchChar = text.charAt(i);
 
-		// iterate over all the diacritics
-        for(var key in diacritics) {
-            var indexChar = diacritics[key].indexOf(searchChar);
-			
-			// check if the current character is a diacritic
-            if (indexChar !== -1) {
-				// as the character is a diacritic, adds into the result array, the key of the found diacritic
-                result.push(key);
-                foundChar = true;
-                break;
-            }
-        }
+    // If applicable replace the diacritic character with the real one or use the original value
+    result += searchChar in compiledDiactitics ? compiledDiactitics[searchChar] : searchChar;
+  }
 
-        // check if the character was not found
-        if (!foundChar) {
-			// as the character was not found, returns it
-            result.push(searchChar);
-        }
-    }
-
-    return result.join("");
+  return result;
 };


### PR DESCRIPTION
I came around this module while looking at this bug in vue-good-table: https://github.com/xaksis/vue-good-table/issues/545

I found out that the lookup of the diacriticless-module is quite slow. This PR is introducing a precompiled lookup-table for the search/replacement of diacritics. It may slows down the initial loading as it has to precompile the diacritics-map into the lookup-table and it may uses more memory, but is faster in the end.

The other performance-gaining change is to use string-concatination rather than array.push() and .join().


(Some simple benchmarks with https://benchmarkjs.com/ showed these numbers on my 2019 MacbookAir, 1,2 GHz Quad-Core Intel Core i7:

```
Original x 3,308 ops/sec ±4.86% (79 runs sampled)
Lookuptable x 239,810 ops/sec ±3.15% (84 runs sampled)
```

So this PR may have a positive effect on the multiple table-plugins which lists this module as dependency)